### PR TITLE
CompatHelper: add new compat entry for Measurements at version 2, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -34,6 +34,7 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
 JSON = "0.21"
+Measurements = "2"
 julia = "1.6, 1.7, 1.8, 1.9, 1.10"
 
 [extras]


### PR DESCRIPTION
This pull request sets the compat entry for the `Measurements` package to `2`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.
Note: Consider registering a new release of your package immediately after merging this PR, as downstream packages may depend on this for tests to pass.