### PR TITLE
CompatHelper: add new compat entry for HDF5 at version 0.17, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -33,6 +33,7 @@ TypedTables = "9d95f2ec-7b3d-5a63-8d20-e2491e220bb9"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
+HDF5 = "0.17"
 JSON = "0.21"
 julia = "1.6, 1.7, 1.8, 1.9, 1.10"
 


### PR DESCRIPTION
This pull request sets the compat entry for the `HDF5` package to `0.17`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.
Note: Consider registering a new release of your package immediately after merging this PR, as downstream packages may depend on this for tests to pass.