### PR TITLE
CompatHelper: bump compat for CairoMakie to 0.15, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -35,7 +35,7 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 [compat]
 BSplineKit = "0.19"
 CSV = "0.10"
-CairoMakie = "0.13"
+CairoMakie = "0.13, 0.15"
 DataFrames = "1.7"
 Distributions = "0.25"
 HDF5 = "0.17"


### PR DESCRIPTION
This pull request changes the compat entry for the `CairoMakie` package from `0.13` to `0.13, 0.15`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.